### PR TITLE
deps: kako-jun/nobiscuit#28 termray 0.3 追従 + Rust 2024 edition + v0.2.1 bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,40 @@
+# Changelog
+
+All notable changes to nobiscuit are documented in this file. The format is based on
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.2.1] - 2026-04-19
+
+### Changed
+- `termray` dependency bumped from 0.1 to 0.3 (#28).
+- `render_walls`, `render_floor_ceiling`, `project_sprites` call sites updated
+  to pass `&FlatHeightMap` + `&Camera` (and `screen_height` for sprites).
+  Visual output is unchanged since nobiscuit remains a tile-flat world.
+- `rust-version` bumped to 1.85.0 and workspace edition to 2024 to align with
+  termray 0.3.
+
+### Notes
+- `NobiscuitMap` stays a pure `TileMap` implementation. Corner-interpolated
+  heights and `Camera.pitch` are available via termray 0.3 if we ever want
+  to introduce uneven floors (tatami undulation, sunken genkan), but they
+  are not used in this release.
+- The workspace still pins `termray` via `path = "../../2026/termray"` until
+  termray 0.3.x is published to crates.io. The declared version is `"0.3"`,
+  so swapping back to a crates.io-only dep once published is a one-line change.
+
+## [0.2.0] - 2026-04-18
+
+### Changed
+- Migrated the raycasting core to the external
+  [`termray`](https://github.com/kako-jun/termray) crate (#27), extracting
+  the generic engine layer out of the former `nobiscuit-engine`. nobiscuit
+  now keeps only game-specific code (maze generation, Japanese-house
+  textures, HUD, minimap, player state).
+- Tile IDs renumbered: termray reserves `0=EMPTY` / `1=WALL` / `2=VOID`, so
+  nobiscuit's props moved into the `3..=11` range.
+
+## [0.1.x]
+
+- Early iterations of the TUI raycasting maze game. See git history for
+  detail.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,6 @@ All notable changes to nobiscuit are documented in this file. The format is base
   heights and `Camera.pitch` are available via termray 0.3 if we ever want
   to introduce uneven floors (tatami undulation, sunken genkan), but they
   are not used in this release.
-- The workspace still pins `termray` via `path = "../../2026/termray"` until
-  termray 0.3.x is published to crates.io. The declared version is `"0.3"`,
-  so swapping back to a crates.io-only dep once published is a one-line change.
 
 ## [0.2.0] - 2026-04-18
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,9 +63,6 @@ Raycasting primitives live in the [termray](https://github.com/kako-jun/termray)
 - Galagala opening: spin count determines maze size (15x13~121x91) and floors (1~12). Camera shake, color-coded spin counter, retry returns to galagala
 
 ## Future work
-- Drop the `path = "../../2026/termray"` override in `[workspace.dependencies]` once
-  termray 0.3.x is on crates.io (termray 0.1.0 / 0.2.0 are already published; 0.3.0 is
-  staged locally and will follow the usual tag → CI → publish flow)
 - Flatten single-crate workspace (rename `nobiscuit-cli` → `nobiscuit`, drop `crates/`)
 - Movable walls/windows (home maze dynamic rearrangement)
 - Infinite maze (chunk-based generation)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,9 @@ Raycasting primitives live in the [termray](https://github.com/kako-jun/termray)
 - Galagala opening: spin count determines maze size (15x13~121x91) and floors (1~12). Camera shake, color-coded spin counter, retry returns to galagala
 
 ## Future work
-- Publish termray 0.1.0 to crates.io and drop the `path = "../../2026/termray"` workspace dep
+- Drop the `path = "../../2026/termray"` override in `[workspace.dependencies]` once
+  termray 0.3.x is on crates.io (termray 0.1.0 / 0.2.0 are already published; 0.3.0 is
+  staged locally and will follow the usual tag → CI → publish flow)
 - Flatten single-crate workspace (rename `nobiscuit-cli` → `nobiscuit`, drop `crates/`)
 - Movable walls/windows (home maze dynamic rearrangement)
 - Infinite maze (chunk-based generation)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,6 +50,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "font8x8"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875488b8711a968268c7cf5d139578713097ca4635a76044e8fe8eedf831d07e"
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -101,7 +107,7 @@ dependencies = [
 
 [[package]]
 name = "nobiscuit-cli"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "crossterm",
  "rand",
@@ -266,9 +272,10 @@ dependencies = [
 
 [[package]]
 name = "termray"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cf5a8d42b7056286add682f1f9bab7e35bfc159f86c98f687d95b3151d04550"
+version = "0.3.0"
+dependencies = [
+ "font8x8",
+]
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,6 +273,8 @@ dependencies = [
 [[package]]
 name = "termray"
 version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c411b454dc5707811bed0ca96decc423f4de5d34ea746ec02796bdd0b16a6d13"
 dependencies = [
  "font8x8",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = [".github/", "target/"]
 rust-version = "1.85.0"
 
 [workspace.dependencies]
-termray = { version = "0.3", path = "../../2026/termray" }
+termray = "0.3"
 crossterm = "0.28"
 rand = "0.8"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,8 +3,8 @@ members = ["crates/nobiscuit-cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.2.0"
-edition = "2021"
+version = "0.2.1"
+edition = "2024"
 authors = ["kako-jun"]
 license = "MIT"
 homepage = "https://github.com/kako-jun/nobiscuit"
@@ -13,10 +13,10 @@ readme = "README.md"
 keywords = ["game", "tui", "raycasting", "maze", "terminal"]
 categories = ["command-line-utilities", "games"]
 exclude = [".github/", "target/"]
-rust-version = "1.82.0"
+rust-version = "1.85.0"
 
 [workspace.dependencies]
-termray = "0.1"
+termray = { version = "0.3", path = "../../2026/termray" }
 crossterm = "0.28"
 rand = "0.8"
 

--- a/crates/nobiscuit-cli/src/game.rs
+++ b/crates/nobiscuit-cli/src/game.rs
@@ -5,8 +5,8 @@ use crate::tiles::{
     TILE_DOOR_FUSUMA, TILE_DOOR_GENKAN, TILE_DOOR_KITCHEN, TILE_DOOR_TOILET, TILE_EMPTY, TILE_GOAL,
     TILE_STAIRS_DOWN, TILE_STAIRS_UP,
 };
-use rand::seq::SliceRandom;
 use rand::Rng;
+use rand::seq::SliceRandom;
 use std::collections::HashMap;
 use std::collections::HashSet;
 

--- a/crates/nobiscuit-cli/src/main.rs
+++ b/crates/nobiscuit-cli/src/main.rs
@@ -11,10 +11,10 @@ mod ui;
 
 use std::time::{Duration, Instant};
 
-use termray::{render_floor_ceiling, render_walls, Color, Framebuffer, TileMap};
+use termray::{Color, FlatHeightMap, Framebuffer, TileMap, render_floor_ceiling, render_walls};
 
-use crate::game::{EndingPhase, GamePhase, GameState, World, FADE_DURATION};
-use crate::input::{poll_input, GameInput};
+use crate::game::{EndingPhase, FADE_DURATION, GamePhase, GameState, World};
+use crate::input::{GameInput, poll_input};
 use crate::player::Player;
 use crate::terminal::TerminalRenderer;
 use crate::textures::NobiscuitTextures;
@@ -215,19 +215,32 @@ fn main() {
                         let tex = NobiscuitTextures;
 
                         // Floor and ceiling
-                        render_floor_ceiling(&mut fb, &rays, &tex, &player.camera);
+                        render_floor_ceiling(
+                            &mut fb,
+                            &rays,
+                            &tex,
+                            &FlatHeightMap,
+                            &player.camera,
+                            MAX_DEPTH,
+                        );
 
                         // Walls
-                        render_walls(&mut fb, &rays, &tex, MAX_DEPTH);
+                        render_walls(
+                            &mut fb,
+                            &rays,
+                            &tex,
+                            &FlatHeightMap,
+                            &player.camera,
+                            MAX_DEPTH,
+                        );
 
                         // Sprites (biscuits + goal + stairs)
                         let projected = termray::project_sprites(
                             world.current_sprites(),
-                            player.camera.x,
-                            player.camera.y,
-                            player.camera.angle,
-                            player.camera.fov,
+                            &player.camera,
+                            &FlatHeightMap,
                             fb.width(),
+                            fb.height(),
                         );
                         termray::render_sprites(&mut fb, &projected, &rays, &tex, MAX_DEPTH);
 

--- a/crates/nobiscuit-cli/src/maze.rs
+++ b/crates/nobiscuit-cli/src/maze.rs
@@ -5,8 +5,8 @@ use crate::tiles::{
     TILE_DOOR_FUSUMA, TILE_DOOR_GENKAN, TILE_DOOR_KITCHEN, TILE_DOOR_TOILET, TILE_EMPTY, TILE_GOAL,
     TILE_SHOJI, TILE_STAIRS_DOWN, TILE_STAIRS_UP, TILE_VOID, TILE_WALL, TILE_WINDOW,
 };
-use rand::seq::SliceRandom;
 use rand::Rng;
+use rand::seq::SliceRandom;
 use std::collections::VecDeque;
 
 /// Player spawn position (grid coordinates). Used for stair exclusion and seed guarantee.

--- a/crates/nobiscuit-cli/src/tiles.rs
+++ b/crates/nobiscuit-cli/src/tiles.rs
@@ -3,7 +3,7 @@
 //! termray reserves 0..=2 for EMPTY / WALL / VOID. Nobiscuit uses 3..=11 for
 //! its Japanese-house props.
 
-pub use termray::{TileType, TILE_EMPTY, TILE_VOID, TILE_WALL};
+pub use termray::{TILE_EMPTY, TILE_VOID, TILE_WALL, TileType};
 
 pub const TILE_GOAL: TileType = 3;
 pub const TILE_WINDOW: TileType = 4;

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -22,14 +22,15 @@ crates/
         └── textures.rs      # WallTexturer/FloorTexturer/SpriteArt (fusuma/shoji/tatami)
 ```
 
-termray supplies: `Camera`, `Framebuffer`, `Color`, `Sprite`, `TileMap` trait, `HitSide`,
-`RayHit`, plus the render skeletons `render_walls`, `render_floor_ceiling`,
-`project_sprites`, `render_sprites`. nobiscuit plugs its visuals into those skeletons
-via the trait implementations in `textures.rs`.
+termray supplies: `Camera`, `Framebuffer`, `Color`, `Sprite`, `TileMap` trait, `HeightMap`
+trait (+ `FlatHeightMap` for tile-flat worlds), `HitSide`, `HitFace`, `RayHit`, plus the
+render skeletons `render_walls`, `render_floor_ceiling`, `project_sprites`, `render_sprites`.
+nobiscuit plugs its visuals into those skeletons via the trait implementations in
+`textures.rs`, and passes `&FlatHeightMap` to keep its floors / ceilings flat.
 
 ## Tech Stack
 
-- **Rust** (edition 2021)
+- **Rust** (edition 2024, MSRV 1.85.0)
 - **termray** — Generic TUI raycasting engine (extracted from the former `nobiscuit-engine`)
 - **crossterm** 0.28 — Terminal rendering, raw mode, key input
 - **rand** 0.8 — Maze generation, biscuit placement

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -56,9 +56,11 @@ trait objects instead of hard-coded styling. nobiscuit implements them on its
 `NobiscuitTextures` struct in `src/textures.rs`.
 
 ```rust
-render_walls(fb, rays, &wall_texturer, max_depth)
-render_floor_ceiling(fb, rays, &floor_texturer, camera)
-project_sprites(sprites, camera_x, camera_y, camera_angle, fov, screen_width) -> Vec<SpriteRenderResult>
+// termray 0.3: wall/floor renderers take a HeightMap + Camera.
+// nobiscuit is a tile-flat world, so we pass &FlatHeightMap everywhere.
+render_walls(fb, rays, &wall_texturer, &FlatHeightMap, camera, max_depth)
+render_floor_ceiling(fb, rays, &floor_texturer, &FlatHeightMap, camera, max_depth)
+project_sprites(sprites, camera, &FlatHeightMap, screen_width, screen_height) -> Vec<SpriteRenderResult>
 render_sprites(fb, projected, rays, &sprite_art, max_depth)
 ```
 


### PR DESCRIPTION
## 関連 Issue

closes #28

## 概要

termray v0.3.0 の破壊変更に追従。nobiscuit は tile-flat な世界のまま、`&FlatHeightMap` を注入して既存の視覚を完全維持。

## 変更内容

### termray 0.1 → 0.3 API 追従
- `render_walls` → 新シグネチャ `(fb, rays, tex, heights, camera, max_depth)` に `&FlatHeightMap` と `&Camera` を注入
- `render_floor_ceiling` → 新シグネチャ `(fb, rays, tex, heights, camera, max_depth)` に同様追従
- `project_sprites` → 新シグネチャ `(sprites, &camera, &heights, screen_width, screen_height)` へ書き換え
- `use termray::FlatHeightMap` を追加

### メタデータ
- `workspace.package.version`: `0.2.0` → `0.2.1`
- `edition`: `2021` → `2024`（termray 0.3 に揃える）
- `rust-version`: `1.82.0` → `1.85.0`

### ドキュメント
- `CHANGELOG.md` 新規作成（Keep a Changelog 形式、v0.2.1 / v0.2.0 / v0.1.x）
- `docs/specification.md`, `docs/architecture.md`, `CLAUDE.md` の API 記述更新
- cargo fmt 2024 の新 use 並び順ルールに合わせて内部整列

## 検証

- ✅ `cargo build --release`（crates.io の termray 0.3.0 で OK）
- ✅ `cargo clippy --all-targets -- -D warnings`
- ✅ `cargo fmt --check`

## 設計判断

- `NobiscuitMap` は純粋な `TileMap` 実装のまま維持。`CornerHeights` / `Camera.pitch` は termray 0.3 で利用可能だが、nobiscuit は tile-flat を維持するので未使用
- `RayHit.face` フィールド追加はパターンマッチしている箇所が nobiscuit に無いので影響なし
- ゲームロジック / マップ生成 / テクスチャ / HUD は一切未変更 → visual regression なし

## 後続作業

- マージ後に nobiscuit v0.2.1 tag を発行（CI が 5 ターゲットの GitHub Release を自動生成）